### PR TITLE
Added Exception Tracking via Sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,19 @@ Tests for the Backend are beeing handled through the npm module supertest. To ru
 npm run test
 ```
 
+## Reporting / Logging
+
+For reporting of applications errors [Sentry](https://sentry.io/) is used. A new route that will always throw an error was established called:
+
+```
+https://music-meteorology-production.herokuapp.com/debug-sentry
+https://music-meteorology-development.herokuapp.com/debug-sentry
+https://music-meteorology-staging1.herokuapp.com/debug-sentry
+https://music-meteorology-staging2.herokuapp.com/debug-sentry
+```
+
+Bugs with sentry are visible within the dashboard and can be intraged into a Slack channel.
+
 ## Architecture and Workflow
 
 ![](documentation/database-schema.png)

--- a/package-lock.json
+++ b/package-lock.json
@@ -403,6 +403,74 @@
         "@types/yargs": "^13.0.0"
       }
     },
+    "@sentry/core": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.6.2.tgz",
+      "integrity": "sha512-grbjvNmyxP5WSPR6UobN2q+Nss7Hvz+BClBT8QTr7VTEG5q89TwNddn6Ej3bGkaUVbct/GpVlI3XflWYDsnU6Q==",
+      "requires": {
+        "@sentry/hub": "5.6.1",
+        "@sentry/minimal": "5.6.1",
+        "@sentry/types": "5.6.1",
+        "@sentry/utils": "5.6.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.6.1.tgz",
+      "integrity": "sha512-m+OhkIV5yTAL3R1+XfCwzUQka0UF/xG4py8sEfPXyYIcoOJ2ZTX+1kQJLy8QQJ4RzOBwZA+DzRKP0cgzPJ3+oQ==",
+      "requires": {
+        "@sentry/types": "5.6.1",
+        "@sentry/utils": "5.6.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.6.1.tgz",
+      "integrity": "sha512-ercCKuBWHog6aS6SsJRuKhJwNdJ2oRQVWT2UAx1zqvsbHT9mSa8ZRjdPHYOtqY3DoXKk/pLUFW/fkmAnpdMqRw==",
+      "requires": {
+        "@sentry/hub": "5.6.1",
+        "@sentry/types": "5.6.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/node": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.6.2.tgz",
+      "integrity": "sha512-A9CELco6SjF4zt8iS1pO3KdUVI2WVhtTGhSH6X04OVf2en1fimPR+Vs8YVY/04udwd7o+3mI6byT+rS9+/Qzow==",
+      "requires": {
+        "@sentry/core": "5.6.2",
+        "@sentry/hub": "5.6.1",
+        "@sentry/types": "5.6.1",
+        "@sentry/utils": "5.6.1",
+        "cookie": "0.3.1",
+        "https-proxy-agent": "2.2.1",
+        "lru_map": "0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        }
+      }
+    },
+    "@sentry/types": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.6.1.tgz",
+      "integrity": "sha512-Kub8TETefHpdhvtnDj3kKfhCj0u/xn3Zi2zIC7PB11NJHvvPXENx97tciz4roJGp7cLRCJsFqCg4tHXniqDSnQ=="
+    },
+    "@sentry/utils": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.6.1.tgz",
+      "integrity": "sha512-rfgha+UsHW816GqlSRPlniKqAZylOmQWML2JsujoUP03nPu80zdN43DK9Poy/d9OxBxv0gd5K2n+bFdM2kqLQQ==",
+      "requires": {
+        "@sentry/types": "5.6.1",
+        "tslib": "^1.9.3"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
@@ -540,6 +608,14 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
       "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
       "dev": true
+    },
+    "agent-base": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
     },
     "ajv": {
       "version": "6.10.2",
@@ -1615,6 +1691,19 @@
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
       }
     },
     "escape-html": {
@@ -2936,6 +3025,30 @@
         "sshpk": "^1.7.0"
       }
     },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -4181,6 +4294,11 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
+    },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
     "make-dir": {
       "version": "2.1.0",
@@ -6117,6 +6235,11 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
   },
   "homepage": "https://github.com/labs15-music-meteorologist/backend#readme",
   "dependencies": {
+    "@sentry/node": "^5.6.2",
     "cors": "^2.8.5",
     "cross-env": "^5.2.0",
     "dotenv": "^8.0.0",
+    "es6-promise": "^4.2.8",
     "express": "^4.17.1",
     "helmet": "^3.20.0",
     "jsonwebtoken": "^8.5.1",

--- a/server.js
+++ b/server.js
@@ -2,22 +2,43 @@ const express = require('express');
 const helmet = require('helmet');
 const cors = require('cors');
 const morgan = require('morgan');
+
 require('dotenv').config();
 
 const UsersRouter = require('./api/users/user-router.js');
-const server = express();
 
+const server = express();
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: 'https://d1fc669b08fb4d33b336f1b64a48ae5b@sentry.io/1537793',
+});
+
+server.use(Sentry.Handlers.requestHandler());
 server.use(express.json());
 server.use(helmet());
 server.use(morgan('dev'));
 server.use(cors());
 
-server.get('/', (req, res) => {
+server.get('/', function rootHandler(req, res) {
   res.send(
     `Welcome to the ${
       process.env.DEPLOYMENT
     } environment API of Music Meteorologist!`,
   );
+});
+
+server.get('/debug-sentry', function mainHandler(req, res) {
+  throw new Error('My first Sentry error!');
+});
+
+server.use(Sentry.Handlers.errorHandler());
+
+server.use(function onError(err, req, res, next) {
+  // The error id is attached to `res.sentry` to be returned
+  // and optionally displayed to the user for support.
+  res.statusCode = 500;
+  res.end(res.sentry + '\n');
 });
 
 server.use('/v1/users', UsersRouter);

--- a/server.spec.js
+++ b/server.spec.js
@@ -35,8 +35,6 @@ describe('GET A SINGLE USER OK', () => {
   });
 });
 
-/* ENDPOINT TEST API RUNNING */
-
 /* VALIDATION TESTS REGISTER A USER*/
 describe('REGISTER A USER NO BODY', () => {
   it('returns 400 No Body Provided', () => {


### PR DESCRIPTION
For sentry to be working it needed to have the dependency https://www.npmjs.com/package/es6-promise installed. Then it was configured through the unique key which might or might not be a environmental variable in the future so it does not gets exposed like an API key? And now all errors of the backend are trackable through the dashboard and maybe soon in Slack.