### PR TITLE
updated recommendation endpoint to check for data and shape

### DIFF
--- a/api/recommendations/recommendation.js
+++ b/api/recommendations/recommendation.js
@@ -7,37 +7,57 @@ require('dotenv').config();
 const DS_URL = process.env.DS_URL
 
 router.post('/' , async (req,res)=> {
-  const r = req.body
+  const r = req.body.audio_features
   let output = {}
   // TODO: add additional checks that all fields are not undefined or null
   const audioFeatures = {
-    "acousticness": 0.934,
-    "danceability": 0.186,
-    "energy": 0.107,
-    "instrumentalness": 0,
-    "key": 5,
-    "liveness": 0.297,
-    "loudness": -14.802,
-    "mode": 1,
-    "speechiness": 0.0347,
-    "tempo": 107.095,
-    "time_signature": 4,
-    "valence": 0.149
+    "acousticness": r.acousticness,
+    "danceability": r.danceability,
+    "energy": r.energy,
+    "instrumentalness": r.instrumentalness,
+    "key": r.key,
+    "liveness": r.liveness,
+    "loudness": r.loudness,
+    "mode": r.mode,
+    "speechiness": r.speechiness,
+    "tempo": r.tempo,
+    "time_signature": r.time_signature,
+    "valence": r.valence
   }
-  try {
-    // TODO: turn this into a post request and send in audioFeatures in the request body
-    // TODO: Write real error messages
-    await axios.post(DS_URL,{audio_features:audioFeatures})
-    .then(res => {
-      output = res.data
-    }).catch(error => {
-      res.status(400).json(error)
-    })
-    res.status(200).json(output)
-  }
-  catch (error){
-    res.status(400).json(error);
-  }
+  const requestCompare = Object.keys(r)
+  const postShape = [
+    'acousticness',
+    'danceability',
+    'energy',
+    'instrumentalness',
+    'key',
+    'liveness',
+    'loudness',
+    'mode',
+    'speechiness',
+    'tempo',
+    'time_signature',
+    'valence'
+  ]
+    if (JSON.stringify(requestCompare) === JSON.stringify(postShape)){
+      try {
+        // TODO: turn this into a post request and send in audioFeatures in the request body
+        // TODO: Write real error messages
+        await axios.post(DS_URL,{audio_features:audioFeatures})
+        .then(res => {
+          output = res.data
+        }).catch(error => {
+          res.status(400).json(error)
+        })
+        res.status(200).json(output)
+      }
+      catch (error){
+        res.status(400).json({error:`Bad Request ${error}`});
+      }
+    }else{
+      res.status(400).json("Error posting audio_features, check your data shape")
+    }
+
 })
 
 


### PR DESCRIPTION
Updated recommender endpoint to only accept a post request in the right format. Moving forward if the shape is not correct the request will be denied. Requests should be in this format and order
```json
{
    "audio_features": {
        "acousticness": 0.934,
        "danceability": 0.186,
        "energy": 0.107,
        "instrumentalness": 0,
        "key": 5,
        "liveness": 0.297,
        "loudness": -14.802,
        "mode": 1,
        "speechiness": 0.0347,
        "tempo": 107.095,
        "time_signature": 4,
        "valence": 0.149
    }
}
```